### PR TITLE
add inherits for 'org.gwtproject.regexp.RegExp'

### DIFF
--- a/domino-rest-shared/src/main/module.gwt.xml
+++ b/domino-rest-shared/src/main/module.gwt.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module>
+    <inherits name="org.gwtproject.regexp.RegExp"/>
     <source path=""/>
 </module>


### PR DESCRIPTION
the module descriptor for the module `dommino-rest-shared` does not inherits `org.gwtproject.regexp.RegExp`.

Added inherits.