### PR TITLE
remove dependency to gwt-event sources 

### DIFF
--- a/domino-rest-gwt/pom.xml
+++ b/domino-rest-gwt/pom.xml
@@ -56,12 +56,6 @@
             <version>HEAD-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.gwtproject.event</groupId>
-            <artifactId>gwt-event</artifactId>
-            <version>HEAD-SNAPSHOT</version>
-            <classifier>sources</classifier>
-        </dependency>
-        <dependency>
             <groupId>org.gwtproject.xhr</groupId>
             <artifactId>gwt-xhr</artifactId>
             <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
sources are contained inside the jar. no need to add additional sources jar. Due to the update of the project to Maven the sources jar will no longer be created.